### PR TITLE
Support httpUploadProgress option

### DIFF
--- a/dist/lib/streamToS3.js
+++ b/dist/lib/streamToS3.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -12,7 +12,7 @@ module.exports = function (response, S3Client) {
   // The promise() method is not supported on s3 upload, so we again explicitly
   // created promise that we can reject/resolve once the file is uploaded to S3
   return new Promise(function (resolve, reject) {
-    S3Client.upload(uploadParams, options, function (err, uploadResult) {
+    S3Client.upload(uploadParams, options).on('httpUploadProgress', s3Options.httpUploadProgress).send(function (err, uploadResult) {
       if (err) return reject(err);
       return resolve(uploadResult);
     });

--- a/dist/lib/streamToS3.js
+++ b/dist/lib/streamToS3.js
@@ -2,6 +2,8 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var NOOP = function NOOP() {};
+
 module.exports = function (response, S3Client) {
   var s3Options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
@@ -12,7 +14,7 @@ module.exports = function (response, S3Client) {
   // The promise() method is not supported on s3 upload, so we again explicitly
   // created promise that we can reject/resolve once the file is uploaded to S3
   return new Promise(function (resolve, reject) {
-    S3Client.upload(uploadParams, options).on('httpUploadProgress', s3Options.httpUploadProgress).send(function (err, uploadResult) {
+    S3Client.upload(uploadParams, options).on('httpUploadProgress', s3Options.httpUploadProgress || NOOP).send(function (err, uploadResult) {
       if (err) return reject(err);
       return resolve(uploadResult);
     });

--- a/src/lib/streamToS3.js
+++ b/src/lib/streamToS3.js
@@ -1,3 +1,5 @@
+const NOOP = () => {};
+
 module.exports = (response, S3Client, s3Options = {}) => {
   const uploadParams = { Body: response, ...s3Options };
   // TODO: s3 options could be parameterized and taken from the options object
@@ -7,7 +9,7 @@ module.exports = (response, S3Client, s3Options = {}) => {
   // created promise that we can reject/resolve once the file is uploaded to S3
   return new Promise((resolve, reject) => {
     S3Client.upload(uploadParams, options)
-      .on('httpUploadProgress', s3Options.httpUploadProgress)
+      .on('httpUploadProgress', s3Options.httpUploadProgress || NOOP)
       .send((err, uploadResult) => {
         if (err) return reject(err);
         return resolve(uploadResult);

--- a/src/lib/streamToS3.js
+++ b/src/lib/streamToS3.js
@@ -6,9 +6,11 @@ module.exports = (response, S3Client, s3Options = {}) => {
   // The promise() method is not supported on s3 upload, so we again explicitly
   // created promise that we can reject/resolve once the file is uploaded to S3
   return new Promise((resolve, reject) => {
-    S3Client.upload(uploadParams, options, (err, uploadResult) => {
-      if (err) return reject(err);
-      return resolve(uploadResult);
-    });
+    S3Client.upload(uploadParams, options)
+      .on('httpUploadProgress', s3Options.httpUploadProgress)
+      .send((err, uploadResult) => {
+        if (err) return reject(err);
+        return resolve(uploadResult);
+      });
   });
 };

--- a/src/lib/streamToS3.test.js
+++ b/src/lib/streamToS3.test.js
@@ -9,8 +9,13 @@ const fakeClient = {
 describe("streamToS3", () => {
   it("Should upload the stream", async () => {
     expect.assertions(2);
-    fakeClient.upload.mockImplementationOnce((params, opts, cb) => {
-      cb(null, { success: true });
+    fakeClient.upload.mockImplementationOnce((params, opts) => {
+      return {
+        on() { return this },
+        send(cb) {
+          cb(null, { success: true });
+        }
+      };
     });
 
     const result = await streamToS3("body", fakeClient, {
@@ -26,7 +31,6 @@ describe("streamToS3", () => {
         Key: "test-key"
       },
       { partSize: 10 * 1024 * 1024, queueSize: 1 },
-      expect.any(Function)
     );
 
     expect(result).toEqual({ success: true });
@@ -35,13 +39,55 @@ describe("streamToS3", () => {
   it("Should reject on error", async () => {
     expect.assertions(1);
     const mockError = new Error("S3 Error");
-    fakeClient.upload.mockImplementationOnce((params, opts, cb) => {
-      cb(mockError);
+
+    fakeClient.upload.mockImplementationOnce((params, opts) => {
+      return {
+        on() { return this },
+        send(cb) {
+          cb(mockError);
+        }
+      };
     });
+
     try {
       await streamToS3("body", fakeClient);
     } catch (e) {
       expect(e).toBe(mockError);
     }
+  });
+
+  it("Should call optional httpUploadProgress", async () => {
+    expect.assertions(3);
+    fakeClient.upload.mockImplementationOnce((params, opts) => {
+      return {
+        on(_, fn) {
+          fn();
+          return this;
+        },
+        send(cb) {
+          cb(null, { success: true });
+        }
+      };
+    });
+    const mockHttpUploadProgress = jest.fn();
+
+    const result = await streamToS3("body", fakeClient, {
+      Bucket: "test-bucket",
+      Key: "test-key",
+      httpUploadProgress: mockHttpUploadProgress,
+    });
+
+    // Ensure that the s3 upload is being called with the right params
+    expect(fakeClient.upload).toHaveBeenCalledWith(
+      {
+        Body: "body",
+        Bucket: "test-bucket",
+        Key: "test-key",
+      },
+      { partSize: 10 * 1024 * 1024, queueSize: 1 },
+    );
+
+    expect(mockHttpUploadProgress).toHaveBeenCalled();
+    expect(result).toEqual({ success: true });
   });
 });


### PR DESCRIPTION
Resolves #1 

Supports a new s3 option `httpUploadProgress` which takes a function:

```
const options = {
  s3: {
    Bucket: "sample-bucket",
    Key: "path/to/file.html",
    httpUploadProgress: function(evt) {
       console.log('Progress:', evt.loaded, '/', evt.total);
    }
  }
};
```